### PR TITLE
Add tokenizer support for selected models in Sagemaker Endpoint Backend

### DIFF
--- a/crates/llm-chain-sagemaker-endpoint/Cargo.toml
+++ b/crates/llm-chain-sagemaker-endpoint/Cargo.toml
@@ -23,6 +23,7 @@ serde_with = "3.2.0"
 strum = "0.25.0"
 strum_macros = "0.25.2"
 thiserror = "1.0.40"
+tokenizers ={ version = "0.13.4", features = ["http"]}
 
 [dev-dependencies]
 tokio = { version = "1.28.2", features = ["macros", "rt"] }

--- a/crates/llm-chain-sagemaker-endpoint/src/executor.rs
+++ b/crates/llm-chain-sagemaker-endpoint/src/executor.rs
@@ -91,8 +91,7 @@ impl llm_chain::traits::Executor for Executor {
     }
 
     fn answer_prefix(&self, _prompt: &Prompt) -> Option<String> {
-        // Not all models expose this information.
-        unimplemented!();
+        None
     }
 
     fn get_tokenizer(&self, options: &Options) -> Result<Self::StepTokenizer<'_>, TokenizerError> {

--- a/crates/llm-chain-sagemaker-endpoint/src/executor.rs
+++ b/crates/llm-chain-sagemaker-endpoint/src/executor.rs
@@ -2,10 +2,8 @@ use crate::model::Formatter;
 use crate::model::Model;
 use async_trait::async_trait;
 
-use llm_chain::options;
-use llm_chain::options::Opt;
-use llm_chain::options::Options;
-use llm_chain::options::OptionsCascade;
+use llm_chain::options; // for the top-level macro
+use llm_chain::options::{Opt, Options, OptionsCascade};
 use llm_chain::output::Output;
 use llm_chain::prompt::Prompt;
 use llm_chain::tokens::{
@@ -141,7 +139,7 @@ impl Tokenizer for SageMakerEndpointTokenizer {
                 let encoding = tokenizer
                     .encode(doc, false)
                     .map_err(|_| TokenizerError::TokenizationError)?;
-                let ids: Vec<i32> = encoding.get_ids().iter().map(|x| *x as i32).collect();
+                let ids: Vec<_> = encoding.get_ids().iter().map(|x| *x as i32).collect();
                 Ok(TokenCollection::from(ids))
             }
             None => unimplemented!("This model does not have a tokenizer impelmentation."),
@@ -151,12 +149,7 @@ impl Tokenizer for SageMakerEndpointTokenizer {
     fn to_string(&self, tokens: TokenCollection) -> Result<String, TokenizerError> {
         match &self.tokenizer {
             Some(tokenizer) => {
-                let ids: Vec<u32> = tokens
-                    .as_i32()
-                    .unwrap()
-                    .iter()
-                    .map(|x| *x as u32)
-                    .collect::<Vec<u32>>();
+                let ids: Vec<_> = tokens.as_i32().unwrap().iter().map(|x| *x as u32).collect();
                 Ok(tokenizer
                     .decode(ids.as_slice(), false)
                     .map_err(|_| TokenizerError::TokenizationError)?)
@@ -169,7 +162,6 @@ impl Tokenizer for SageMakerEndpointTokenizer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::Model;
     use llm_chain::traits::Executor;
 
     #[test]

--- a/crates/llm-chain-sagemaker-endpoint/src/model.rs
+++ b/crates/llm-chain-sagemaker-endpoint/src/model.rs
@@ -141,6 +141,14 @@ impl Model {
             _ => self.to_string(),
         }
     }
+    /// Convert the model to its HuggingFace model name
+    pub fn to_huggingface_name(&self) -> String {
+        match &self {
+            Model::Falcon7BInstruct => "tiiuae/falcon-7b-instruct".to_string(),
+            Model::Falcon40BInstruct => "tiiuae/falcon-40b-instruct".to_string(),
+            _ => self.to_string(),
+        }
+    }
 }
 
 /// The `Model` enum implements the `ToString` trait, allowing you to easily convert it to a string.

--- a/crates/llm-chain-sagemaker-endpoint/src/model.rs
+++ b/crates/llm-chain-sagemaker-endpoint/src/model.rs
@@ -149,6 +149,14 @@ impl Model {
             _ => self.to_string(),
         }
     }
+    
+    pub fn context_window_size(&self) -> Option<i32> {
+        match &self {
+            Model::Falcon7BInstruct  => Some(2048),
+            Model::Falcon40BInstruct => Some(2048),
+            _ => None
+        }
+    }
 }
 
 /// The `Model` enum implements the `ToString` trait, allowing you to easily convert it to a string.

--- a/crates/llm-chain-sagemaker-endpoint/src/model.rs
+++ b/crates/llm-chain-sagemaker-endpoint/src/model.rs
@@ -119,7 +119,7 @@ impl Formatter for Model {
 
     fn parse_response(&self, response: InvokeEndpointOutput) -> String {
         match self {
-            Model::Falcon7BInstruct | Model::Falcon40BInstruct  => {
+            Model::Falcon7BInstruct | Model::Falcon40BInstruct => {
                 let output = String::from_utf8(response.body.unwrap().into_inner()).unwrap();
                 let output_json: serde_json::Value = serde_json::from_str(&output).unwrap();
 
@@ -149,12 +149,12 @@ impl Model {
             _ => self.to_string(),
         }
     }
-    
+
     pub fn context_window_size(&self) -> Option<i32> {
         match &self {
-            Model::Falcon7BInstruct  => Some(2048),
+            Model::Falcon7BInstruct => Some(2048),
             Model::Falcon40BInstruct => Some(2048),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/crates/llm-chain-sagemaker-endpoint/src/model.rs
+++ b/crates/llm-chain-sagemaker-endpoint/src/model.rs
@@ -119,7 +119,7 @@ impl Formatter for Model {
 
     fn parse_response(&self, response: InvokeEndpointOutput) -> String {
         match self {
-            Model::Falcon7BInstruct => {
+            Model::Falcon7BInstruct | Model::Falcon40BInstruct  => {
                 let output = String::from_utf8(response.body.unwrap().into_inner()).unwrap();
                 let output_json: serde_json::Value = serde_json::from_str(&output).unwrap();
 

--- a/crates/llm-chain/src/tokens.rs
+++ b/crates/llm-chain/src/tokens.rs
@@ -76,6 +76,7 @@ impl<E: traits::Executor> ExecutorTokenCountExt for E {}
 
 /// Struct representing token count information, including the maximum tokens allowed and the
 /// total number of tokens used.
+#[derive(Debug, PartialEq)]
 pub struct TokenCount {
     /// The maximum number of tokens allowed.
     max_tokens: i32,


### PR DESCRIPTION
This adds the missing tokenizer support for Falcon-7B-instruct and Falcon-40B-instruct models hosted on Sagemake endpoint.